### PR TITLE
Cleanup to meter definitions.

### DIFF
--- a/grammars/Makefile
+++ b/grammars/Makefile
@@ -11,4 +11,4 @@ utility.far: utility.grm inventory.far
 	thraxcompiler --input_grammar=$< --output_far=$@
 
 clean:
-	rm -f inventory.far byte.far utility.far
+	rm -f *.far

--- a/grammars/inventory.grm
+++ b/grammars/inventory.grm
@@ -9,52 +9,53 @@ import 'byte.grm' as b;
 
 # We include j, v, and diaeresized vowels because these are
 # present in Pharr's text.
-export GRAPHEME =
+export GRAPHEME = Optimize[
     "a" | "b" | "c" | "d" | "e" | "f" | "g" |
     "h" | "i" | "j" | "k" | "l" | "m" | "n" |
     "o" | "p" | "q" | "r" | "s" | "t" | "u" |
     "v" | "w" | "x" | "y" | "z" | "ā" | "ē" |
     "ī" | "ō" | "ū" | "ȳ" | "ä" | "ë" | "ï" |
-    "ö" | "ü" | b.kSpace;
+    "ö" | "ü" | b.kSpace];
 
-# Graphemic vowels, really.
-export VOWEL =
+# Graphemic vowels.
+export VOWEL = Optimize[
     "a" | "e" | "i" | "o" | "u" | "ā" | "ē" | "ī" | "ō" | "ū" |
-    "ȳ" | "ä" | "ë" | "ï" | "ö" | "ü";
+    "ȳ" | "ä" | "ë" | "ï" | "ö" | "ü"];
 
-export PHONEME =
+# Phonemic vowels.
+oral_vowel = "a" | "e" | "i" | "o" | "u";
+nasal_vowel = "ã" | "ẽ" | "ĩ" | "õ" | "ũ";
+export SHORT_VOWEL = Optimize[oral_vowel | nasal_vowel];
+export LONG_VOWEL = SHORT_VOWEL "ː";
+
+# Phonemic consonants.
+export VOICELESS_STOP = Optimize["p" | "t" | "k"];
+export VOICED_STOP = Optimize["b" | "d" | "g"];
+export STOP = Optimize[VOICELESS_STOP | VOICED_STOP];
+export LIQUID = Optimize["l" | "r"];
+export CONSONANT = Optimize[STOP | LIQUID | "f" | "h" | "j" | "m" | "n" |
+                            "ŋ" |"s" | "w" | "z"];
+
+# Boundary symbols.
+export BOW = Optimize[b.kSpace | "[BOS]"];  # Beginning of a word.
+export EOW = Optimize[b.kSpace | "[EOS]"];  # End of a word.
+
+export PHONEME = Optimize[
     "a" | "aː" | "ãː" | "b" | "d" | "e" | "eː" |
     "ẽː" | "f" | "g" | "h" | "i" | "iː" | "ĩː" |
     "j" | "k" | "kw" | "l" | "m" | "n" | "ŋ" |
     "o" | "oː" | "õː" | "p" | "r" | "s" | "t" |
-    "u" | "uː" | "ũː" | "w" | "z" | b.kSpace;
+    "u" | "uː" | "ũː" | "w" | "z" | b.kSpace];
 
-export METER_SYMBOL = "U" | # Short nucleus.
-                      "–" | # Long nucleus.
-                      "O" | # Onset.
-                      "C" | # Coda.
-                      "L" | # Longum.
-                      "B" | # Brevis.
-                      "D" | # Dactyl.
-                      "S" | # Spondee.
-                      "T";  # Trochee.
-
-voiceless_stop = "p" | "t" | "k";
-voiced_stop = "b" | "d" | "g";
-stop = voiceless_stop | voiced_stop;
-liquid = "l" | "r";
-other_consonants = "f" | "gw" | "h" | "j" | "kw" |
-                   "m" | "n" | "ŋ" | "s" | "w" | "z";
-export SINGLE_CONSONANT = stop | liquid | other_consonants;
-
-multa_cum_liquida = (stop | "f") liquid;
-s_complex_onset = "s" (voiceless_stop "r"? | "pl" | "w");
-export CONSONANT_CLUSTER = multa_cum_liquida | s_complex_onset;
-
-oral_vowel = "a" | "e" | "i" | "o" | "u";
-nasal_vowel = "ã" | "ẽ" | "ĩ" | "õ" | "ũ";
-export SHORT_VOWEL = oral_vowel | nasal_vowel;
-export LONG_VOWEL = SHORT_VOWEL "ː";
-
-export BOW = (b.kSpace | "[BOS]"); # Beginning of a word.
-export EOW = (b.kSpace | "[EOS]"); # End of a word.
+# Prosodic symbols.
+export NUCLEUS = Optimize["U" |  # Short nucleus.
+                          "-"];  # Long nucleus.
+export SYLLABLE = Optimize[NUCLEUS |
+                           "O" |  # Onset.
+                           "C"];  # Coda.
+export WEIGHT = Optimize["L" |  # Longum.
+                         "B"];  # Brevis.
+export FOOT = Optimize["D" |  # Dactyl.
+                       "S" |  # Spondee.
+                       "T"];  # Trochee.
+export PROSODIC_SYMBOL = Optimize[SYLLABLE | WEIGHT | FOOT];

--- a/grammars/meter.grm
+++ b/grammars/meter.grm
@@ -7,95 +7,98 @@ import 'inventory.grm' as i;
 import 'byte.grm' as b;
 import 'utility.grm' as u;
 
-sigma_star = (i.METER_SYMBOL | i.PHONEME)*;
+sigma_star = (i.PROSODIC_SYMBOL | i.PHONEME)*;
 
-# Syllable parsing.
-long_nucleus = Optimize[u.Rewrite[i.LONG_VOWEL : "–", sigma_star]];
+## Syllable parsing.
+
+long_nucleus = Optimize[u.Rewrite[i.LONG_VOWEL : "-", sigma_star]];
 
 short_nucleus = Optimize[u.Rewrite[i.SHORT_VOWEL : "U", sigma_star]];
 
-onset = Optimize[CDRewrite[(i.CONSONANT_CLUSTER | i.SINGLE_CONSONANT) : "O", "",
-                             "–" | "U", sigma_star]];
+muta_cum_liquida = ((i.STOP | "f") i.LIQUID) - ("tl" | "dl");
+s_cluster = "s" ((i.VOICELESS_STOP i.LIQUID?) - "tl");
+labiovelar = ("k" | "g" | "s") "w";
 
-coda = Optimize[u.Rewrite[i.SINGLE_CONSONANT+ : "C", sigma_star]];
+onset = Optimize[CDRewrite[(muta_cum_liquida | s_cluster | labiovelar |
+                           i.CONSONANT) : "O", "", i.NUCLEUS, sigma_star]];
 
-export SYLLABLE_PARSE = Optimize[long_nucleus @ short_nucleus @ onset @ coda];
+coda = Optimize[u.Rewrite[i.CONSONANT+ : "C", sigma_star]];
 
-# Heavy vs. light syllables.
-heavy = ("O"?) ("U" "C" | "–" "C"?) : "L";
+export SYLLABLE = Optimize[long_nucleus @ short_nucleus @ onset @ coda];
+
+## Syllable weight.
+
+heavy = ("O"?) ("U" "C" | "-" "C"?) : "L";
 light = "O"? "U" : "B";
-export WEIGHT_PARSE = Optimize[u.Join[(light | heavy)+, " "]];
+export WEIGHT = Optimize[u.Join[(light | heavy)+, " "]];
 
-# Foot types.
+## Foot types.
+
 dactyl = ("L" " "?) ("B" " "?) ("B" " "?): "D";
 spondee = ("L" " "?) ("L" " "?) : "S";
 trochee = ("L" " "?) ("B" " "?) : "T";
-export FOOT_TYPE = (dactyl | spondee | trochee)*;
+export FEET = (dactyl | spondee | trochee)*;
 
-# Acceptor that acts as a filter on valid sequences of hexameter feet.
+## Filters.
+
+# Filters footing to valid hexameter patterns.
 hexameter = Optimize[Project[(dactyl | spondee){5} (spondee | trochee),
                      'output']];
+export SCAN = Optimize[SYLLABLE @ WEIGHT @ FEET @ hexameter];
 
-export SCAN = Optimize[SYLLABLE_PARSE @ WEIGHT_PARSE @ FOOT_TYPE @ hexameter];
+## Tests syllable parsing.
+test_syllable_1 = AssertEqual[
+  "arma wirũːkwe kanoː trojjaj kwiː priːmus ab oːris" @ SYLLABLE,
+  "UCOU OUO-OU OUO- OUCOUC O- O-OUC UC -OUC"
+];
+test_syllable_2 = AssertEqual[
+  "temperet aː lakrimiːs et jãː noks uːmida kajloː" @ SYLLABLE,
+  "OUCOUOUC - OUOUO-C UC O- OUC -OUOU OUCO-"
+];
+test_syllable_3 = AssertEqual[
+  "ajraːtoːs jamkwe ekskiːsaː trabe firma kawaːwit" @ SYLLABLE,
+  "UCO-O-C OUCOU UCO-O- OUOU OUCOU OUO-OUC"
+];
+test_syllable_4 = AssertEqual[
+  "juːdikiũː paridis spreːtajkwe injuːria formaj" @ SYLLABLE,
+  "O-OUOU- OUOUOUC O-OUCOU UCO-OUU OUCOUC"
+];
+test_syllable_5 = AssertEqual[
+  "faːs awt ille sinit superiː reːŋnaːtor olumpiː" @ SYLLABLE,
+  "O-C UC UCOU OUOUC OUOUO- O-CO-OUC UOUCO-"
+];
+test_syllable_6 = AssertEqual[
+  "tũː bitiaj dedit iŋkrepitaːns ille impiger hawsit" @ SYLLABLE,
+  "O- OUOUUC OUOUC UCOUOUO-C UCOU UCOUOUC OUCOUC"
+];
+test_syllable_7 = AssertEqual[
+  "hajret et interdũː gremioː fowet iːnskia diːdoː" @ SYLLABLE,
+  "OUCOUC UC UCOUCO- OUOU- OUOUC -COUU O-O-"
+];
+test_syllable_8 = AssertEqual[
+  "kũː wenit awlajiːs jãː seː reːgiːna superbiːs" @ SYLLABLE,
+  "O- OUOUC UCOUO-C O- O- O-O-OU OUOUCO-C"
+];
 
-test_parse_1 = AssertEqual[
-  "arma wirũːkwe kanoː trojjaj kwiː priːmus ab oːris" @ SYLLABLE_PARSE,
-  "UCOU OUO–OU OUO– OUCOUC O– O–OUC UC –OUC"
-];
-test_parse_2 = AssertEqual[
-  "temperet aː lakrimiːs et jãː noks uːmida kajloː" @ SYLLABLE_PARSE,
-  "OUCOUOUC – OUOUO–C UC O– OUC –OUOU OUCO–"
-];
-test_parse_3 = AssertEqual[
-  "ajraːtoːs jamkwe ekskiːsaː trabe firma kawaːwit" @ SYLLABLE_PARSE,
-  "UCO–O–C OUCOU UCO–O– OUOU OUCOU OUO–OUC"
-];
-test_parse_4 = AssertEqual[
-  "juːdikiũː paridis spreːtajkwe injuːria formaj" @ SYLLABLE_PARSE,
-  "O–OUOU– OUOUOUC O–OUCOU UCO–OUU OUCOUC"
-];
-test_parse_5 = AssertEqual[
-  "faːs awt ille sinit superiː reːŋnaːtor olumpiː" @ SYLLABLE_PARSE,
-  "O–C UC UCOU OUOUC OUOUO– O–CO–OUC UOUCO–"
-];
-test_parse_6 = AssertEqual[
-  "tũː bitiaj dedit iŋkrepitaːns ille impiger hawsit" @ SYLLABLE_PARSE,
-  "O– OUOUUC OUOUC UCOUOUO–C UCOU UCOUOUC OUCOUC"
-];
-test_parse_7 = AssertEqual[
-  "hajret et interdũː gremioː fowet iːnskia diːdoː" @ SYLLABLE_PARSE,
-  "OUCOUC UC UCOUCO– OUOU– OUOUC –COUU O–O–"
-];
-test_parse_8 = AssertEqual[
-  "kũː wenit awlajiːs jãː seː reːgiːna superbiːs" @ SYLLABLE_PARSE,
-  "O– OUOUC UCOUO–C O– O– O–O–OU OUOUCO–C"
-];
-
-# Tests heavy and light against various syllable types.
-test_weight_1 = AssertEqual[
-  "OU U" @ WEIGHT_PARSE,
-  "B B"
-]; # Light syllable types.
-test_weight_2 = AssertEqual[
-  "O–C O– –C –" @ WEIGHT_PARSE,
-  "L L L L"
-]; # Heavy by nature.
-test_weight_3 = AssertEqual[
-  "O–C OUC –C UC" @ WEIGHT_PARSE,
-  "L L L L"
-]; # Heavy by position.
+## Tests weight.
+# Light syllable.
+test_weight_1 = AssertEqual["OU U" @ WEIGHT, "B B"];
+# Heavy by nature.
+test_weight_2 = AssertEqual["O-C O- -C -" @ WEIGHT, "L L L L"];
+# Heavy by position.
+test_weight_3 = AssertEqual["O-C OUC -C UC" @ WEIGHT, "L L L L"]; 
 
 # Complete foot mapping for "Mūsa, mihī causās memorā, quō nūmine laesō."
 test_line_1 = AssertEqual[
-  "muːsa mihiː kawsaːs memoraː kwoː nuːmine lajsoː" @ SYLLABLE_PARSE,
-  "O–OU OUO– OUCO–C OUOUO– O– O–OUOU OUCO–"
+  "muːsa mihiː kawsaːs memoraː kwoː nuːmine lajsoː" @ SYLLABLE,
+  "O-OU OUO- OUCO-C OUOUO- O- O-OUOU OUCO-"
 ];
 test_line_2 = AssertEqual[
-  "O–OU OUO– OUCO–C OUOUO– O– O–OUOU OUCO–" @ WEIGHT_PARSE,
+  "O-OU OUO- OUCO-C OUOUO- O- O-OUOU OUCO-" @ WEIGHT,
   "LB BL LL BBL L LBB LL"
 ];
 test_line_3 = AssertEqual[
-  "LB BL LL BBL L LBB LL" @ FOOT_TYPE,
+  "LB BL LL BBL L LBB LL" @ FEET,
   "DSDSDS"
 ];
 test_scan_1 = AssertEqual[
@@ -105,15 +108,15 @@ test_scan_1 = AssertEqual[
 
 # Complete foot mapping for "Urbs antīqua fuit (Tyriī tenuēre colōnī)."
 test_line_5 = AssertEqual[
-  "urps antiːkwa fuit turiiː tenueːre koloːniː" @ SYLLABLE_PARSE,
-  "UC UCO–OU OUUC OUOU– OUOU–OU OUO–O–"
+  "urps antiːkwa fuit turiiː tenueːre koloːniː" @ SYLLABLE,
+  "UC UCO-OU OUUC OUOU- OUOU-OU OUO-O-"
 ];
 test_line_6 = AssertEqual[
-  "UC UCO–OU OUUC OUOU– OUOU–OU OUO–O–" @ WEIGHT_PARSE,
+  "UC UCO-OU OUUC OUOU- OUOU-OU OUO-O-" @ WEIGHT,
   "L LLB BL BBL BBLB BLL"
 ];
 test_line_7 = AssertEqual[
-  "L LLB BL BBL BBLB BLL" @ FOOT_TYPE,
+  "L LLB BL BBL BBLB BLL" @ FEET,
   "SDDDDS"
 ];
 test_scan_2= AssertEqual[
@@ -123,15 +126,15 @@ test_scan_2= AssertEqual[
 
 # Complete foot mapping for "quidve dolēns rēgīna deum tot volvere cāsūs."
 test_line_8 = AssertEqual[
-  "kwidwe doleːns reːgiːna deũː tot wolwere kaːsuːs" @ SYLLABLE_PARSE,
-  "OUCOU OUO–C O–O–OU OU– OUC OUCOUOU O–O–C"
+  "kwidwe doleːns reːgiːna deũː tot wolwere kaːsuːs" @ SYLLABLE,
+  "OUCOU OUO-C O-O-OU OU- OUC OUCOUOU O-O-C"
 ];
 test_line_9 = AssertEqual[
-  "OUCOU OUO–C O–O–OU OU– OUC OUCOUOU O–O–C" @ WEIGHT_PARSE,
+  "OUCOU OUO-C O-O-OU OU- OUC OUCOUOU O-O-C" @ WEIGHT,
   "LB BL LLB BL L LBB LL"
 ];
 test_line_10 = AssertEqual[
-  "LB BL LLB BL L LBB LL" @ FOOT_TYPE,
+  "LB BL LLB BL L LBB LL" @ FEET,
   "DSDSDS"
 ];
 test_scan_3 = AssertEqual[
@@ -139,6 +142,7 @@ test_scan_3 = AssertEqual[
   "DSDSDS"
 ];
 
+# Tests a defective line.
 test_defective_1 = AssertNull[
   "kũː siːk uːnanimãː adlokwitur male saːna soroːrẽː" @ SCAN
 ];


### PR DESCRIPTION
1. Uses ASCII '-' rather than en-dash: easier to type
2. Renames some basic definitions.
3. Moves syllable parsing definitions mostly into meter.grm.
4. Adds more inventory definitions.
5. Fix to `Makefile`: wasn't deleting all the FARs.