### PR TITLE
Fix all '3's in Aeneid04

### DIFF
--- a/data/Aeneid/Aeneid04.txt
+++ b/data/Aeneid/Aeneid04.txt
@@ -49,7 +49,7 @@ conjugiō tālī! Teucrum comitantibus armīs
 Pūnica sē quantīs attollet glōria rēbus!
 Tū modo posce deōs veniam, sacrīsque litātīs
 indulgē hospitiō causāsque innecte morandī,
-dum pelagō dēsaevit hiems et aquo3sus Orīōn,
+dum pelagō dēsaevit hiems et aquōsus Orīōn,
 quassātaeque ratēs, dum nōn tractābile caelum."
 Hīs dictīs impēnsō animum flāmmavit amōre
 spemque dedit dubiae mentī solvitque pudōrem.
@@ -119,7 +119,7 @@ in nemus īre parant, ubi prīmōs crāstinus ortūs
 extulerit Tītān radiīsque retēxerit orbem.
 Hīs ego nigrantem commixtā grandine nimbum,
 dum trepidant ālae, saltūsque indāgine cingunt,
-de3super īnfundam et tonitrū caelum omne ciēbō.
+dēsuper īnfundam et tonitrū caelum omne ciēbō.
 Diffugient comitēs et nocte tegentur opācā:
 spēluncam Dīdō dux et Trojānus eandem
 dēvenient. Aderō et, tua sī mihi certa voluntās,
@@ -157,7 +157,7 @@ At puer Ascanius mediīs in vallibus ācrī
 gaudet equō jamque hōs cursū, jam praeterit illōs,
 spūmantemque darī pecora inter inertia vōtīs
 optat aprum, aut fulvum dēscendere monte leōnem.
-Intereā magnō misce3rī murmure caelum
+Intereā magnō miscērī murmure caelum
 incipit, īnsequitur commixtā grandine nimbus,
 et Tyriī comitēs passim et Trojāna juventūs
 Dardaniusque nepōs Veneris dīversa per agrōs


### PR DESCRIPTION
Makes #17 obsolete.


FYI, in case you're wondering why I made this typo before: on the MacOS
international keyboard, if you hold the Apple key plus 'e' it'll place a
macron on the next letter. The '3' key is immediately above 'e'...