### PR TITLE
Adds a conda environmental specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,29 @@ License
 The engine is released under an Apache 2.0 license. Please see
 [LICENSE.txt](LICENSE.txt) for details.
 
+Installation
+------------
+
+[Conda](http://conda.io) is recommended for a reproducible environment. Assuming
+that Conda (either Miniconda or Anaconda) is available, the following command
+creates the environment `scansion`.
+
+```bash
+conda env create -f environment.yml
+```
+
+This only needs to be done once. The following command then activates the
+environment.
+
+```bash
+conda activate scansion
+```
+
+This step needs to be repeated each time you start a new shell.
+
 Authors
 -------
 
-* Jillian Chang
-* Kyle Gorman
+-   Jillian Chang
+-   [Kyle Gorman](kgorman@gc.cuny.edu)
+

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: LatinScansion
+channels:
+ - defaults
+ - conda-forge
+dependencies:
+ - make=4.2.1
+ - pynini=2.1.4
+ - python=3.8.10
+ - thrax=1.3.6


### PR DESCRIPTION
This YAML file allows for reproducible builds anywhere Conda can be used. At present it installs make, Python 3.8, Pynini, and Thrax.

The README explains how to use this.

We can use something simpler (e.g., Python's built-in `requirements.txt` support) for the web app since it itself doesn't need things like Thrax---we only need that at compile-time, not run-time.