### PR TITLE
Adds escaping before norm rewriting

### DIFF
--- a/src/scan.py
+++ b/src/scan.py
@@ -17,14 +17,13 @@ def main(args: argparse.Namespace) -> None:
         far = stack.enter_context(pynini.Far(args.far, "r"))
         source = stack.enter_context(open(args.input, "r"))
         sink = stack.enter_context(open(args.output, "w"))
+        lines = [line.rstrip() for line in lines]
         scanned = scansion.scan_document(
-            # TODO(kbg): I don't love this `readlines` approach, which would
-            # be painful for huge documents.
             far["NORMALIZE"],
             far["PRONOUNCE"],
             far["VARIABLE"],
             far["METER"],
-            source.readlines(),
+            lines,
             args.name if args.name else os.path.normpath(args.input),
         )
         text_format.PrintMessage(scanned, sink, as_utf8=True)

--- a/src/scansion.py
+++ b/src/scansion.py
@@ -34,10 +34,11 @@ def scan_line(
     Returns:
       A populated Line message.
     """
-    line = scansion_pb2.Line(line_number=line_number, text=text.strip())
+    line = scansion_pb2.Line(line_number=line_number, text=text)
     # Applies normalization.
     try:
-        line.norm = rewrite.top_rewrite(line.text, normalize_rule)
+        # We need escapes for normalization since Pharr uses [ and ].
+        line.norm = rewrite.top_rewrite(pynini.escape(line.text), normalize_rule)
     except rewrite.Error:
         logging.error(
             "Rewrite failure during normalization (line %d): %r",

--- a/src/scansion_test.py
+++ b/src/scansion_test.py
@@ -10,7 +10,6 @@ import scansion
 
 
 class ScansionTest(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -20,20 +19,23 @@ class ScansionTest(unittest.TestCase):
                 far["NORMALIZE"],
                 far["PRONOUNCE"],
                 far["VARIABLE"],
-                far["METER"]
+                far["METER"],
             )
 
     # TODO(jillianchang): There should be way more tests than this.
 
     def test_aen_1_1(self):
-        # Scans the first line of the Aeneid.
+        # Scans line 1.1.
         text = "Arma virumque canō, Trojae quī prīmus ab ōris"
         line = self.scan_line(text)  # No explicit line number.
         self.assertEqual(line.line_number, -1)
         self.assertEqual(line.text, text)
-        self.assertEqual(line.norm, "arma virumque canō trojae quī prīmus ab ōris")
-        self.assertEqual(line.pron, "arma wirũːkwe kanoː trojjaj kwiː priːmu sa boːris")
-
+        self.assertEqual(
+            line.norm, "arma virumque canō trojae quī prīmus ab ōris"
+        )
+        self.assertEqual(
+            line.pron, "arma wirũːkwe kanoː trojjaj kwiː priːmu sa boːris"
+        )
 
     def test_aen_1_534(self):
         # Scans line 1.534, which is clearly defective (and in this case, it's
@@ -44,6 +46,17 @@ class ScansionTest(unittest.TestCase):
         self.assertEqual(line.text, text)
         self.assertEqual(line.norm, "hic cursus fuit")
         self.assertTrue(line.defective)
+
+    def test_aen_2_77(self):
+        # Scans line 2.77, which has brackets in Pharr's edition.
+        text = "[Ille haec dēpositā tandem formīdine fātur:]"
+        line = self.scan_line(text, 77)
+        self.assertEqual(line.line_number, 77)
+        self.assertEqual(line.text, text)
+        self.assertEqual(
+            line.norm, "ille haec dēpositā tandem formīdine fātur"
+        )
+        self.assertFalse(line.defective)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Pynini treats [ and ] as enclosing a generating symbol unless they are
"escaped" immediately before the rewrite.

Adds a test to check this behavior, also.