### PR TITLE
attempt to address muta cum liquida variable behavior

### DIFF
--- a/grammars/meter.grm
+++ b/grammars/meter.grm
@@ -24,8 +24,8 @@ onset = Optimize[
   # "x", "mn", and "phth" onsets are found word-initially in Greek names.
   CDRewrite[(s_cluster | "ks" | "mn" | "pt") : "O",
             i.BOW, i.NUCLEUS, sigma_star] @
-  CDRewrite[(muta_cum_liquida | labiovelar |
-            i.CONSONANT) : "O", "", i.NUCLEUS, sigma_star]
+  CDRewrite[(muta_cum_liquida | labiovelar | i.CONSONANT) : "O",
+            "", i.NUCLEUS, sigma_star, 'rtl', 'opt']
 ];
 
 coda = Optimize[u.Rewrite[i.CONSONANT+ : "C", sigma_star]];
@@ -85,6 +85,7 @@ test_syllable_8 = AssertEqual[
   "kũː wenit awlajiːs jãː seː reːgiːna superbiːs" @ SYLLABLE,
   "O- OUOUC UCOUO-C O- O- O-O-OU OUOUCO-C"
 ];
+
 # Testing that word initial sC (s consonant) is an onset but a medial sC splits into coda onset.
 test_sc_1 = AssertEqual[
   "impulerit tantajnanimiːs kajlestibu siːraj" @ SYLLABLE,
@@ -101,6 +102,18 @@ test_ks_1 = AssertEqual[
 test_ks_2 = AssertEqual[
   "uːnius ob noksãː et furiaːs ajjaːkis oiːleiː" @ SYLLABLE,
   "-OUUC UC OUCO- UC OUOU-C UCO-OUC U-OU-"
+];
+
+# Testing the multivariable muta cum liquida behavior. MCL'S
+# are normally parsed as onsets, but can also split into onset coda
+# as per poetic license.
+test_without_split_1 = AssertEqual[
+  "kekropidaj jussiː miserũː septeːna kwotanniːs" @ SYLLABLE,
+  "OUOUOUOUC OUCO- OUOUO- OUCO-OU OUOUCO-C"
+];
+test_with_split_1 = AssertEqual[
+  "kekropidaj jussiː miserũː septeːna kwotanniːs" @ SYLLABLE,
+  "OUCOUOUOUC OUCO- OUOUO- OUCO-OU OUOUCO-C"
 ];
 
 ## Tests weight.
@@ -163,12 +176,6 @@ test_line_10 = AssertEqual[
 test_scan_3 = AssertEqual[
   "kwidwe doleːns reːgiːna deũː tot wolwere kaːsuːs" @ METER,
   "DSDSDS"
-];
-
-## Meter testing for optional rules.
-meter_syllable_1 = AssertEqual[
-  "oːstia diːwe sopũː studiiːskwasperrima belliː" @ SYLLABLE,
-  "-COUU O-OU OUO- OUOU-COUCOUCOUOU OUCO-"
 ];
 
 # Tests a defective line.


### PR DESCRIPTION
I know that there's something wrong with this new edit, since the combined grammar isn't able to scan lines as it used to. Do you have suggestions for how to improve this current meter grammar to allow the "variable" behavior?

Additionally, I had to delete all the intermediary tests, because I think the 'opt' and weight in the new muta cum liquida rule messes that up (?)