### PR TITLE
Modify pronounciation grammar to deal with diphthongs that are follow…

### DIFF
--- a/grammars/pronounce.grm
+++ b/grammars/pronounce.grm
@@ -48,7 +48,7 @@ ei_exceptions = Optimize[u.RewriteWord[("dein": "dẽːj") |
 # When an "i" occurs intervocalically (between two vowels),
 # it is realized as a glide: [jj]. Pharr writes intervocalic "i" as "j."
 geminate_intervocalic_i = Optimize[CDRewrite["j" : "jj",
-                                             i.VOWEL, i.VOWEL, sigma_star]];
+                                             i.PHONEMIC_VOWEL, i.PHONEMIC_VOWEL, sigma_star]];
 
 diphthongization = Optimize[u.Rewrite[("ae" : "aj") |
                                       ("oe" : "oj") |
@@ -117,11 +117,11 @@ gn = Optimize[
 ];
 
 rules = Optimize[
-    geminate_intervocalic_i @ u_loss @ nasalization @
-    qu @ eu_exceptions @ ou_exceptions @ ui_exceptions @
-    ei_exceptions @ digraphs @ diphthongization @ diaeresis @
-    long_monophthongs @ b_devoicing @ ngu @ unconditioned_rewrites @
-    nasal_place_assimilation @ gn
+    u_loss @ nasalization @ qu @ eu_exceptions @
+    ou_exceptions @ ui_exceptions @ ei_exceptions @
+    digraphs @ diphthongization @ diaeresis @ long_monophthongs @
+    b_devoicing @ ngu @ unconditioned_rewrites @
+    geminate_intervocalic_i @ nasal_place_assimilation @ gn
 ];
 
 # Constrains input to the graphemes and output to the phonemes.
@@ -213,6 +213,12 @@ test_pron_14 = AssertEqual[
 test_pron_15 = AssertEqual[
     "plācēmus ventōs et gnōsia rēgna petāmus" @ PRONOUNCE,
     "plaːkeːmus wentoːs et noːsia reːŋna petaːmus"
+];
+
+# Tests diphthong followed by a short vowel.
+test_pron_16 = AssertEqual[
+    "aeoliam venit hīc vastō rēx aeolus antrō" @ PRONOUNCE,
+    "ajjoliãː wenit hiːk wastoː reːks ajjolus antroː"
 ];
 
 # TODO:


### PR DESCRIPTION
…ed by short onsets

In our old grammar, a diphthong followed by a short onset such as "aeole" would be mapped as "ajole." So, as per the meter grammar, the syllables would look like "UOUOU," but the j in the diphthong should treated as the coda (it should be "UCUOU"). 

To fix this, I switched around the composition of the pron rules so that geminate j rule applies after the diphthong rule is applied, hence "aeole" turns into "ajjole." I realize this may be incorrect pronunciation-wise, but it was the simplest fix I could think of. 