### PR TITLE
Meter.grm: permit skw onset

### DIFF
--- a/grammars/meter.grm
+++ b/grammars/meter.grm
@@ -16,7 +16,7 @@ long_nucleus = Optimize[u.Rewrite[i.LONG_VOWEL : "-", sigma_star]];
 short_nucleus = Optimize[u.Rewrite[i.SHORT_VOWEL : "U", sigma_star]];
 
 muta_cum_liquida = ((i.STOP | "f") i.LIQUID) - ("tl" | "dl");
-s_cluster = "s" ((i.VOICELESS_STOP (i.LIQUID? | "w")) - "tl");
+s_cluster = "s" ((i.VOICELESS_STOP (i.LIQUID | "w")?) - "tl");
 labiovelar = ("k" | "g" | "s") "w";
 
 onset = Optimize[


### PR DESCRIPTION
I put the two failed Aeneid 2 tests into the meter grammar - it seemed like the syllable parse was failing, so I modified the grammar to allow "skw" onsets (sq). 