### PR TITLE
Added some tests to scansion_tests.py 

### DIFF
--- a/src/scansion_test.py
+++ b/src/scansion_test.py
@@ -43,6 +43,22 @@ class ScansionTest(unittest.TestCase):
         self.assertEqual(line.norm, "hic cursus fuit")
         self.assertTrue(line.defective)
 
+    # Tests that the grammar does not unnecessarily apply resyllabification.
+    def test_aen_1_26(self):
+        text = "exciderant animō; manet altā mente repostum"
+        line = self.scan_line(text)
+        self.assertEqual(
+            line.pron, "ekskiderant animoː mane taltaː mente repostũː"
+        )
+
+    # Tests that the grammar does not unnecessarily apply elision.
+    def test_aen_1_26(self):
+        text = "Ipsa Jovis rapidum jaculāta ē nūbibus ignem"
+        line = self.scan_line(text)
+        self.assertEqual(
+            line.pron, "ipsa jowis rapidũː jakulaːteː nuːbibu siŋnẽː"
+        )
+
     def test_aen_1_247(self):
         text = "Hīc tamen ille urbem Patavī sēdēsque locāvit"
         line = self.scan_line(text)
@@ -117,23 +133,59 @@ class ScansionTest(unittest.TestCase):
         )
 
     # Elision.
-    @unittest.skip("Currently failing")
     def test_aen_2_219(self):
         text = "bis medium amplexī, bis collō squāmea circum"
         line = self.scan_line(text)
         self.assertEqual(
-            line.pron, "bis mediãːpleksiː bis kolloː skwaːmea kircũː"
+            line.pron, "bis mediampleksiː bis kolloː skwaːmea kirkũː"
         )
 
     # Elision.
-    @unittest.skip("Currently failing")
     def test_aen_2_278(self):
         text = "squālentem barbam et concrētōs sanguine crīnīs"
         line = self.scan_line(text)
         self.assertEqual(
-            line.pron, "skwaːlentẽː barbet konkreːtoːs saŋgwine kriːniːs"
+            line.pron, "skwaːlentẽː barbet koŋkreːtoːs saŋgwine kriːniːs"
         )
 
+    # Defective line – first syllable is short.
+    def test_aen_2_506(self):
+        text = "procubuēre tenent danaī quā dēficit ignis"
+        line = self.scan_line(text)
+        self.assertTrue(line.defective)
+
+    @unittest.skip("Requires diastole")
+    def test_aen_2_675(self):
+        text = "haerebat parvumque patrī tendēbat iūlum"
+        line = self.scan_line(text)
+        self.assertEqual(
+            line.pron, "hajrebat parwumkwe patriː tendeːba tiuːlũː"
+        )
+
+    @unittest.skip("Requires diastole")
+    def test_aen_2_744(self):
+        text = "vēnimus hīc demum collēctīs omnibus ūna"
+        line = self.scan_line(text)
+        self.assertEqual(
+            line.pron, "weːnimu siːk demũː kolleːktiːs omnibu suːna"
+        )
+
+    # "Trōia" is technically diastole, but Pharr takes
+    # care of that as he did not rewrite the intervocalic "i" as "j".
+    def test_aen_2_764(self):
+        text = "praedam adservābant hūc undique trōia gaza"
+        line = self.scan_line(text)
+        self.assertEqual(
+            line.pron, "prajdadserwaːbant huːk undikwe troːia gazza"
+        )
+    
+    # Synizesis.
+    def test_aen_3_161(self):
+        text = "Mūtandae sēdēs. Nōn haec tibi lītora suāsit"
+        line = self.scan_line(text)
+        self.assertEqual(
+            line.pron, "muːtandaj seːdeːs noːn hajk tibi liːtora swaːsit"
+        )
 
 if __name__ == "__main__":
     logging.disable("CRITICAL")


### PR DESCRIPTION
This didn't happen before, but the grammar is now applying h-deletion and synezisis even when it's not necessary. Do you know why that's happening? The overapplied synizesis lines (test_aen_1_593 and test_aen_1_682) scanned properly when I tested the lines in the individual grammar files without using synizesis. 

```
FAIL: test_aen_1_247 (__main__.ScansionTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "scansion_test.py", line 65, in test_aen_1_247
    self.assertEqual(
AssertionError: 'iːk tame nillurbẽː patawiː seːdeːskwe lokaːwit' != 'hiːk tame nillurbẽː patawiː seːdeːskwe lokaːwit'
- iːk tame nillurbẽː patawiː seːdeːskwe lokaːwit
+ hiːk tame nillurbẽː patawiː seːdeːskwe lokaːwit
? +


======================================================================
FAIL: test_aen_1_254 (__main__.ScansionTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "scansion_test.py", line 72, in test_aen_1_254
    self.assertEqual(
AssertionError: 'olliː subriːdeːns ominũː sato ratkwe deoːrũː' != 'olliː subriːdeːns hominũː sato ratkwe deoːrũː'
- olliː subriːdeːns ominũː sato ratkwe deoːrũː
+ olliː subriːdeːns hominũː sato ratkwe deoːrũː
?                   +


======================================================================
FAIL: test_aen_1_450 (__main__.ScansionTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "scansion_test.py", line 79, in test_aen_1_450
    self.assertEqual(
AssertionError: 'oːk priːmin luːkoː nowa reːs oblaːta timoːrẽː' != 'hoːk priːmin luːkoː nowa reːs oblaːta timoːrẽː'
- oːk priːmin luːkoː nowa reːs oblaːta timoːrẽː
+ hoːk priːmin luːkoː nowa reːs oblaːta timoːrẽː
? +


======================================================================
FAIL: test_aen_1_477 (__main__.ScansionTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "scansion_test.py", line 86, in test_aen_1_477
    self.assertEqual(
AssertionError: 'loːra teneːns tame nujk kerwiːkskwe komajkwe trauntur' != 'loːra teneːns tame nujk kerwiːkskwe komajkwe trahuntur'
- loːra teneːns tame nujk kerwiːkskwe komajkwe trauntur
+ loːra teneːns tame nujk kerwiːkskwe komajkwe trahuntur
?                                                 +


======================================================================
FAIL: test_aen_1_593 (__main__.ScansionTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "scansion_test.py", line 93, in test_aen_1_593
    self.assertEqual(
AssertionError: 'argentũː parjuswe lapis kirkumdatu rawroː' != 'argentũː pariuswe lapis kirkumdatu rawroː'
- argentũː parjuswe lapis kirkumdatu rawroː
?             ^
+ argentũː pariuswe lapis kirkumdatu rawroː
?             ^


======================================================================
FAIL: test_aen_1_682 (__main__.ScansionTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "scansion_test.py", line 107, in test_aen_1_682
    self.assertEqual(
AssertionError: 'neː kwaː skiːre doloːs medjuswokkurrere possit' != 'neː kwaː skiːre doloːs mediuswokkurrere possit'
- neː kwaː skiːre doloːs medjuswokkurrere possit
?                           ^
+ neː kwaː skiːre doloːs mediuswokkurrere possit
?                           ^


======================================================================
FAIL: test_aen_2_219 (__main__.ScansionTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "scansion_test.py", line 139, in test_aen_2_219
    self.assertEqual(
AssertionError: 'bis medjampleksiː bis kolloː skwaːmea kirkũː' != 'bis mediampleksiː bis kolloː skwaːmea kirkũː'
- bis medjampleksiː bis kolloː skwaːmea kirkũː
?        ^
+ bis mediampleksiː bis kolloː skwaːmea kirkũː
?        ^


======================================================================
FAIL: test_aen_2_764 (__main__.ScansionTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "scansion_test.py", line 176, in test_aen_2_764
    self.assertEqual(
AssertionError: '' != 'prajdadserwaːbant huːk undikwe troːia gazza'
+ prajdadserwaːbant huːk undikwe troːia gazza

======================================================================
FAIL: test_aen_3_161 (__main__.ScansionTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "scansion_test.py", line 183, in test_aen_3_161
    self.assertEqual(
AssertionError: 'muːtandaj seːdeːs noːn ajk tibi liːtora swaːsit' != 'muːtandaj seːdeːs noːn hajk tibi liːtora swaːsit'
- muːtandaj seːdeːs noːn ajk tibi liːtora swaːsit
+ muːtandaj seːdeːs noːn hajk tibi liːtora swaːsit
```