### PR TITLE
Splits pronunciation into two fields

### DIFF
--- a/src/scansion.proto
+++ b/src/scansion.proto
@@ -34,20 +34,27 @@ message Foot {
   optional Type type = 2;
 }
 
-message Line {
-  optional int32 line_number = 1;
-  optional string text = 2;                       // Text before normalization.
-  optional string norm = 3;                       // Text after normalization.
-  optional string pron = 4;                       // IPA pronunciation.
+message Verse {
+  optional int32 verse_number = 1;
+  // Text before normalization.
+  optional string text = 2;
+  // Text after normalization.
+  optional string norm = 3;
+  // IPA pronunciation before poetic variation is introduced.
+  optional string raw_pron = 4;
+  // IPA pronunciation after poetic variation is introduced.
+  optional string var_pron = 5;
 
-  repeated Foot foot = 5;
+  repeated Foot foot = 6;
 
-  optional bool defective = 6 [default = false];
-  optional string comment = 7;                    // Optional notes.
+  // Is the verse defective? (If so, 
+  optional bool defective = 7 [default = false];
+  // Optional notes.
+  optional string comment = 8;
 }
 
-// A document is just a series of lines with optional name metadata.
+// A document is just a series of verses with optional name metadata.
 message Document {
   optional string name = 1;
-  repeated Line line = 2;
+  repeated Verse verse = 2;
 }

--- a/src/scansion.py
+++ b/src/scansion.py
@@ -11,7 +11,7 @@ from pynini.lib import rewrite
 import scansion_pb2  # type: ignore
 
 
-def scan_line(
+def scan_verse(
     normalize_rule: pynini.Fst,
     pronounce_rule: pynini.Fst,
     variable_rule: pynini.Fst,
@@ -20,9 +20,9 @@ def scan_line(
     foot_rule: pynini.Fst,
     hexameter_rule: pynini.Fst,
     text: str,
-    line_number: int = 0,
-) -> scansion_pb2.Line:
-    """Scans a single line of poetry.
+    verse_number: int = 0,
+) -> scansion_pb2.Verse:
+    """Scans a single verse of poetry.
 
     Args:
       normalize_rule: the normalization rule.
@@ -33,41 +33,48 @@ def scan_line(
       foot_rule: the foot rule.
       hexameter_rule: the hexameter rule.
       text: the input text.
-      line_number: an optional line number (defaulting to -1).
+      verse_number: an optional verse number (defaulting to -1).
 
     Returns:
-      A populated Line message.
+      A populated Verse message.
     """
-    line = scansion_pb2.Line(line_number=line_number, text=text)
+    verse = scansion_pb2.Verse(verse_number=verse_number, text=text)
     # TODO: this is ugly but can be substantially redone, eventually.
     try:
         # We need escapes for normalization since Pharr uses [ and ].
-        line.norm = rewrite.top_rewrite(
-            pynini.escape(line.text), normalize_rule
+        verse.norm = rewrite.top_rewrite(
+            pynini.escape(verse.text), normalize_rule
         )
     except rewrite.Error:
-        logging.error("Rewrite failure (line %d)", line.line_number)
-        return line
+        logging.error("Rewrite failure (verse %d)", verse.verse_number)
+        return verse
+    try:
+        verse.raw_pron = rewrite.top_rewrite(verse.norm, pronounce_rule)
+    except rewrite.Error:
+        logging.error("Rewrite failure (verse %d)", verse.verse_number)
+        return verse
     # Computes variant pronunciation candidates.
-    pronounce_lattice = line.norm @ pronounce_rule @ variable_rule
-    pronounce_lattice.project("output")
+    try:
+        pron_lattice = rewrite.rewrite_lattice(verse.raw_pron, variable_rule)
+    except rewrite.Error:
+        logging.error("Rewrite failure (verse %d)", verse.verse_number)
+        return verse
     # Filters with meter information.
-    meter_lattice = (
-        pronounce_lattice
-        @ syllable_rule
-        @ weight_rule
-        @ foot_rule
-        @ hexameter_rule
-    )
+    pron_lattice @= syllable_rule
+    pron_lattice @= weight_rule
+    pron_lattice @= foot_rule
+    pron_lattice @= hexameter_rule
     # Bails out if no hexameter parse is found.
-    if meter_lattice.start() == pynini.NO_STATE_ID:
-        line.defective = True
+    if pron_lattice.start() == pynini.NO_STATE_ID:
+        verse.defective = True
         logging.warning(
-            "Defective line (line %d): %r", line.line_number, line.norm
+            "Defective verse (verse %d): %r", verse.verse_number, verse.norm
         )
-        return line
-    line.pron = pynini.shortestpath(meter_lattice).project("input").string()
-    return line
+        return verse
+    verse.var_pron = (
+        pynini.shortestpath(pron_lattice).project("input").string()
+    )
+    return verse
 
 
 def scan_document(
@@ -78,7 +85,7 @@ def scan_document(
     weight_rule: pynini.Fst,
     foot_rule: pynini.Fst,
     hexameter_rule: pynini.Fst,
-    lines: Iterable[str],
+    verses: Iterable[str],
     name: Optional[str] = None,
 ) -> scansion_pb2.Document:
     """Scans an entire document.
@@ -88,7 +95,7 @@ def scan_document(
       pronounce_rule: the pronunciation rule.
       variable_rule: the rule for introducing pronunciation variation.
       meter_rule: the rule for constraining pronunciation variation to scan.
-      lines: an iterable of lines to scan.
+      verses: an iterable of verses to scan.
       name: optional metadata about the source.
 
     Returns:
@@ -97,7 +104,7 @@ def scan_document(
     document = scansion_pb2.Document(name=name)
     # This binds the rule nmes ahead of time.
     curried = functools.partial(
-        scan_line,
+        scan_verse,
         normalize_rule,
         pronounce_rule,
         variable_rule,
@@ -106,18 +113,18 @@ def scan_document(
         foot_rule,
         hexameter_rule,
     )
-    scanned_lines = 0
-    defective_lines = 0
-    for line_number, line in enumerate(lines, 1):
+    scanned_verses = 0
+    defective_verses = 0
+    for verse_number, verse in enumerate(verses, 1):
         # TODO(kbg): the `append` method copies the message to avoid circular
         # references. Would we improve performance using the `add` method and
         # passing the empty message to be mutated?
-        scanned = curried(line, line_number)
-        document.line.append(scanned)
+        scanned = curried(verse, verse_number)
+        document.verse.append(scanned)
         if scanned.defective:
-            defective_lines += 1
+            defective_verses += 1
         else:
-            scanned_lines += 1
-    logging.info("%d lines scanned", scanned_lines)
-    logging.info("%d lines defective", defective_lines)
+            scanned_verses += 1
+    logging.info("%d verses scanned", scanned_verses)
+    logging.info("%d verses defective", defective_verses)
     return document

--- a/src/scansion_test.py
+++ b/src/scansion_test.py
@@ -14,8 +14,8 @@ class ScansionTest(unittest.TestCase):
     def setUpClass(cls):
         super().setUpClass()
         with pynini.Far("../grammars/all.far", "r") as far:
-            cls.scan_line = functools.partial(
-                scansion.scan_line,
+            cls.scan_verse = functools.partial(
+                scansion.scan_verse,
                 far["NORMALIZE"],
                 far["PRONOUNCE"],
                 far["VARIABLE"],
@@ -25,331 +25,342 @@ class ScansionTest(unittest.TestCase):
                 far["HEXAMETER"],
             )
 
-    # Tests all features of the first line's markup.
+    # Tests all features of the first verse's markup.
     def test_aen_1_1(self):
         text = "Arma virumque canō, Trojae quī prīmus ab ōris"
-        line = self.scan_line(text, 1)
-        self.assertEqual(line.line_number, 1)
-        self.assertEqual(line.text, text)
+        verse = self.scan_verse(text, 1)
+        self.assertEqual(verse.verse_number, 1)
+        self.assertEqual(verse.text, text)
         self.assertEqual(
-            line.norm, "arma virumque canō trojae quī prīmus ab ōris"
+            verse.norm, "arma virumque canō trojae quī prīmus ab ōris"
         )
         self.assertEqual(
-            line.pron, "arma wirũːkwe kanoː trojjaj kwiː priːmu sa boːris"
+            verse.raw_pron, "arma wirũːkwe kanoː trojjaj kwiː priːmus ab oːris"
+        )
+        self.assertEqual(
+            verse.var_pron, "arma wirũːkwe kanoː trojjaj kwiː priːmu sa boːris"
         )
 
-    # Scans line 1.534, which is clearly defective (and in this case, it's
+    # Scans verse 1.534, which is clearly defective (and in this case, it's
     # entirely possible Virgil never finished it).
     def test_aen_1_534(self):
         text = "Hic cursus fuit,"
-        line = self.scan_line(text)
-        self.assertEqual(line.norm, "hic cursus fuit")
-        self.assertTrue(line.defective)
+        verse = self.scan_verse(text)
+        self.assertEqual(verse.norm, "hic cursus fuit")
+        self.assertTrue(verse.defective)
 
     # Tests that the grammar does not unnecessarily apply resyllabification.
     def test_aen_1_26(self):
         text = "exciderant animō; manet altā mente repostum"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "ekskiderant animoː mane taltaː mente repostũː"
+            verse.var_pron, "ekskiderant animoː mane taltaː mente repostũː"
         )
 
     # Tests that the grammar does not unnecessarily apply elision.
-    def test_aen_1_26(self):
+    def test_aen_1_42(self):
         text = "Ipsa Jovis rapidum jaculāta ē nūbibus ignem"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "ipsa jowis rapidũː jakulaːteː nuːbibu siŋnẽː"
+            verse.var_pron, "ipsa jowis rapidũː jakulaːteː nuːbibu siŋnẽː"
         )
 
     def test_aen_1_247(self):
         text = "Hīc tamen ille urbem Patavī sēdēsque locāvit"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "hiːk tame nillurbẽː patawiː seːdeːskwe lokaːwit"
+            verse.var_pron, "hiːk tame nillurbẽː patawiː seːdeːskwe lokaːwit"
         )
 
     def test_aen_1_254(self):
         text = "Ollī subrīdēns hominum sator atque deōrum"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "olliː subriːdeːns hominũː sato ratkwe deoːrũː"
+            verse.var_pron, "olliː subriːdeːns hominũː sato ratkwe deoːrũː"
         )
 
     def test_aen_1_450(self):
         text = "Hōc prīmum in lūcō nova rēs oblāta timōrem"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "hoːk priːmin luːkoː nowa reːs oblaːta timoːrẽː"
+            verse.var_pron, "hoːk priːmin luːkoː nowa reːs oblaːta timoːrẽː"
         )
 
     def test_aen_1_477(self):
         text = "lōra tenēns tamen; huic cervīxque comaeque trahuntur"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "loːra teneːns tame nujk kerwiːkskwe komajkwe trahuntur"
+            verse.var_pron,
+            "loːra teneːns tame nujk kerwiːkskwe komajkwe trahuntur",
         )
 
     def test_aen_1_593(self):
         text = "argentum Pariusve lapis circumdatur aurō."
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "argentũː pariuswe lapis kirkumdatu rawroː"
+            verse.var_pron, "argentũː pariuswe lapis kirkumdatu rawroː"
         )
 
     def test_aen_1_649(self):
         text = "et circumtextum croceō vēlāmen acanthō,"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "et kirkumtekstũː krokeoː weːlaːme nakantoː"
+            verse.var_pron, "et kirkumtekstũː krokeoː weːlaːme nakantoː"
         )
 
     def test_aen_1_682(self):
         text = "nē quā scīre dolōs mediusve occurrere possit."
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "neː kwaː skiːre doloːs mediuswokkurrere possit"
+            verse.var_pron, "neː kwaː skiːre doloːs mediuswokkurrere possit"
         )
 
     def test_aen_1_697(self):
         text = "pallamque et pictum croceō vēlāmen acanthō."
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "pallãːkwet piktũː krokeoː weːlaːme nakantoː"
+            verse.var_pron, "pallãːkwet piktũː krokeoː weːlaːme nakantoː"
         )
 
     # Tests handling of brackets.
     def test_aen_2_77(self):
         text = "[Ille haec dēpositā tandem formīdine fātur:]"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.norm, "ille haec dēpositā tandem formīdine fātur"
+            verse.norm, "ille haec dēpositā tandem formīdine fātur"
         )
-        self.assertFalse(line.defective)
+        self.assertFalse(verse.defective)
 
     # No poetic license rules required.
     def test_aen_2_202(self):
         text = "Lāocoön, ductus Neptūnō sorte sacerdōs,"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "laːokoon duktus neptuːnoː sorte sakerdoːs"
+            verse.var_pron, "laːokoon duktus neptuːnoː sorte sakerdoːs"
         )
 
     # Elision.
     def test_aen_2_219(self):
         text = "bis medium amplexī, bis collō squāmea circum"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "bis mediampleksiː bis kolloː skwaːmea kirkũː"
+            verse.var_pron, "bis mediampleksiː bis kolloː skwaːmea kirkũː"
         )
 
     # Elision.
     def test_aen_2_278(self):
         text = "squālentem barbam et concrētōs sanguine crīnīs"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "skwaːlentẽː barbet koŋkreːtoːs saŋgwine kriːniːs"
+            verse.var_pron, "skwaːlentẽː barbet koŋkreːtoːs saŋgwine kriːniːs"
         )
 
-    # Defective line – first syllable is short.
+    # Defective verse – first syllable is short.
     def test_aen_2_506(self):
         text = "procubuēre tenent danaī quā dēficit ignis"
-        line = self.scan_line(text)
-        self.assertTrue(line.defective)
+        verse = self.scan_verse(text)
+        self.assertTrue(verse.defective)
 
     @unittest.skip("Requires diastole.")
     def test_aen_2_675(self):
         text = "haerebat parvumque patrī tendēbat iūlum"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "hajrebat parwumkwe patriː tendeːba tiuːlũː"
+            verse.var_pron, "hajrebat parwumkwe patriː tendeːba tiuːlũː"
         )
 
     @unittest.skip("Requires diastole.")
     def test_aen_2_744(self):
         text = "vēnimus hīc demum collēctīs omnibus ūna"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "weːnimu siːk demũː kolleːktiːs omnibu suːna"
+            verse.var_pron, "weːnimu siːk demũː kolleːktiːs omnibu suːna"
         )
 
     def test_aen_2_764(self):
         text = "praedam adservābant hūc undique trōja gaza"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "prajdadserwaːbant huːk undikwe troːia gazza"
+            verse.var_pron, "prajdadserwaːbant huːk undikwe troːia gazza"
         )
 
     def test_aen_3_158(self):
         text = "īdem ventūrōs tollēmus in astra nepōtēs"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "iːdẽː wentuːroːs tolleːmu si nastra nepoːteːs"
+            verse.var_pron, "iːdẽː wentuːroːs tolleːmu si nastra nepoːteːs"
         )
 
     # Synizesis.
     def test_aen_3_161(self):
         text = "Mūtandae sēdēs. Nōn haec tibi lītora suāsit"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "muːtandaj seːdeːs noːn hajk tibi liːtora swaːsit"
+            verse.var_pron, "muːtandaj seːdeːs noːn hajk tibi liːtora swaːsit"
         )
 
     def test_aen_3_365(self):
         text = "sōla novum dictūque nefās Harpyja Celaenō"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "soːla nowũː diktuːkwe nefaːs harpujja kelajnoː"
+            verse.var_pron, "soːla nowũː diktuːkwe nefaːs harpujja kelajnoː"
         )
 
     def test_aen_3_464(self):
         text = "dōna dehinc aurō gravia ac sectō elephantō"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "doːna dehiŋk awroː grawiak sektoː elepantoː"
+            verse.var_pron, "doːna dehiŋk awroː grawiak sektoː elepantoː"
         )
 
     @unittest.skip("Requires diastole.")
     def test_aen_3_517(self):
         text = "armātumque aurō circumspicit Ōriōna"
-        line = self.scan_line(text)
-        self.assertEqual(line.pron, "armaːtũːkwe awroː kirkumspiki toːriːoːna")
+        verse = self.scan_verse(text)
+        self.assertEqual(
+            verse.var_pron, "armaːtũːkwe awroː kirkumspiki toːriːoːna"
+        )
 
     def test_aen_3_567(self):
         text = "ter spūmam ēlīsam et rōrantia vīdimus astra."
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "ter spuːmeːliːset roːrantia wiːdimu sastra"
+            verse.var_pron, "ter spuːmeːliːset roːrantia wiːdimu sastra"
         )
 
     @unittest.skip("Requires diastole.")
     def test_aen_4_146(self):
         text = "Crētesque Dryopesque fremunt pictīque Agathyrsī:"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "kreːteskweː druopeskwe fremunt piktiːkwe agatursiː"
+            verse.var_pron,
+            "kreːteskweː druopeskwe fremunt piktiːkwe agatursiː",
         )
 
     def test_aen_4_302(self):
         text = "Thyjas, ubi audītō stimulant trietērica Bacchō"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "tujja subawdiːtoː stimulant trieteːrika bakkoː"
+            verse.var_pron, "tujja subawdiːtoː stimulant trieteːrika bakkoː"
         )
 
     def test_aen_4_324(self):
         text = "(hoc sōlum nōmen quoniam dē conjuge restat)?"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "hok soːlũː noːmen kwoniãː deː konjuge restat"
+            verse.var_pron, "hok soːlũː noːmen kwoniãː deː konjuge restat"
         )
 
     def test_aen_4_369(self):
         text = "Num flētū ingemuit nostrō? Num lūmina flexit?"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "nũː fleːtiŋgemuit nostroː nũː luːmina fleksit"
+            verse.var_pron, "nũː fleːtiŋgemuit nostroː nũː luːmina fleksit"
         )
 
     def test_aen_4_569(self):
         text = "Heja age, rumpe morās. Varium et mūtābile semper"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "hejjage rumpe moraːs wariet muːtaːbile semper"
+            verse.var_pron, "hejjage rumpe moraːs wariet muːtaːbile semper"
         )
 
     @unittest.skip("Requires diastole.")
     def test_aen_4_617(self):
         text = "auxilium implōret videatque indigna suorum"
-        line = self.scan_line(text)
-        self.assertEqual(line.pron, "awksiliimploːret wideatkwindiŋna suoːrũː")
+        verse = self.scan_verse(text)
+        self.assertEqual(
+            verse.var_pron, "awksiliimploːret wideatkwindiŋna suoːrũː"
+        )
 
     @unittest.skip(
-        "bijugoː defies conventional pronounciation rules in that the "
+        "bijugoː defies conventional var_pronounciation rules in that the "
         "intervocalic j is not geminate; perhaps j-gemination is not "
         "triggered in derived environments."
     )
     def test_aen_5_144(self):
         text = "Nōn tam praecipitēs bijugō certāmine campum"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "noːn tãː prajkipiteːs bijugoː kertaːmine kampũː"
+            verse.var_pron, "noːn tãː prajkipiteːs bijugoː kertaːmine kampũː"
         )
 
     @unittest.skip("Requires diastole.")
     def test_aen_5_306(self):
         text = "Gnōsia bina dabō lēvātō lūcida ferrō"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "ŋnoːsia biːna daboː leːwaːtoː luːkida ferroː"
+            verse.var_pron, "ŋnoːsia biːna daboː leːwaːtoː luːkida ferroː"
         )
 
     def test_aen_5_352(self):
         text = "dat Saliō villīs onerōsum atque unguibus aureīs."
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "dat salioː williːs oneroːsatkwuŋgwibu sawrejs"
+            verse.var_pron, "dat salioː williːs oneroːsatkwuŋgwibu sawrejs"
         )
 
     @unittest.skip("Requires diastole.")
     def test_aen_5_520(self):
         text = "qui tamen āeriās tēlum contorsit in aurās"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "kwiː tame naːeriaːs teːlũː kontorsi ti nawraːs"
+            verse.var_pron, "kwiː tame naːeriaːs teːlũː kontorsi ti nawraːs"
         )
 
     @unittest.skip("Requires diastole.")
     def test_aen_5_687(self):
         text = '"Juppiter omnipotēns, si nōndum exōsus ad ūnum'
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "juppite romnipoteːns siː noːndeksoːsu sa duːnũː"
+            verse.var_pron, "juppite romnipoteːns siː noːndeksoːsu sa duːnũː"
         )
 
     def test_aen_5_870(self):
         text = '"Ō nimium caelō et pelagō cōnfīse serēnō'
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "oː nimiũː kajlet pelagoː koːnfiːse sereːnoː"
+            verse.var_pron, "oː nimiũː kajlet pelagoː koːnfiːse sereːnoː"
         )
 
     @unittest.skip("Requires synizesis, but Cj is not a valid onset.")
     def test_aen_6_412(self):
         text = "dēturbat, laxatque forōs; simul accipit alveō"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "deːturbat laksatkwe foroːs simu lakkipi talwjoː"
+            verse.var_pron, "deːturbat laksatkwe foroːs simu lakkipi talwjoː"
         )
 
     @unittest.skip("Requires synizesis and diastole.")
     def test_aen_6_447(self):
         text = "Euadnēnque et Pāsiphaēn; hīs Lāodamīa"
-        line = self.scan_line(text)
-        self.assertEqual(line.pron, "eːwadneːŋkwet paːsipaeːn hiːs laːodamiːa")
+        verse = self.scan_verse(text)
+        self.assertEqual(
+            verse.var_pron, "eːwadneːŋkwet paːsipaeːn hiːs laːodamiːa"
+        )
 
     @unittest.skip("Requires systole.")
     def test_aen_6_507(self):
         text = "Nōmen et arma locum servant; tē, amīce, nequīvī"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "noːme ne tarma lokũː serwant te amiːke nekwiːwiː"
+            verse.var_pron, "noːme ne tarma lokũː serwant te amiːke nekwiːwiː"
         )
 
     @unittest.skip("Requires diastole.")
     def test_aen_6_637(self):
         text = "Hīs demum exāctīs, perfectō mūnere dīvae,"
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "hiːs deːmeksaːktiːs perfektoː muːnere diːwaj"
+            verse.var_pron, "hiːs deːmeksaːktiːs perfektoː muːnere diːwaj"
         )
 
     @unittest.skip("Requires diastole.")
     def test_aen_6_695(self):
         text = 'Ille autem: "Tua me, genitor, tua trīstis imāgō'
-        line = self.scan_line(text)
+        verse = self.scan_verse(text)
         self.assertEqual(
-            line.pron, "illawtẽː tua meː genitor tua triːsti simaːgoː"
+            verse.var_pron, "illawtẽː tua meː genitor tua triːsti simaːgoː"
         )
 
 


### PR DESCRIPTION
The two fields are now called:

* raw_pron
* var_pron

Also corrects some unrelated errors, naming conventions, etc. and streamlines the internals.

The first line now looks like:

```
verse {
  verse_number: 1
  text: "Arma virumque canō, Trojae quī prīmus ab ōris"
  norm: "arma virumque canō trojae quī prīmus ab ōris"
  raw_pron: "arma wirũːkwe kanoː trojjaj kwiː priːmus ab oːris"
  var_pron: "arma wirũːkwe kanoː trojjaj kwiː priːmu sa boːris"
}
```
