### PR TITLE
Adds validation script

### DIFF
--- a/src/scan.py
+++ b/src/scan.py
@@ -1,22 +1,21 @@
 #!/usr/bin/env python
-"""Command-line scansion driver."""
+"""Scans a text document, outputting a Document textproto."""
 
 import argparse
 import contextlib
 import logging
 import os.path
 
-from google.protobuf import text_format  # type: ignore
 import pynini
 
 import scansion
+import textproto
 
 
 def main(args: argparse.Namespace) -> None:
     with contextlib.ExitStack() as stack:
         far = stack.enter_context(pynini.Far(args.far, "r"))
         source = stack.enter_context(open(args.input, "r"))
-        sink = stack.enter_context(open(args.output, "w"))
         lines = [line.rstrip() for line in source]
         document = scansion.scan_document(
             far["NORMALIZE"],
@@ -28,7 +27,7 @@ def main(args: argparse.Namespace) -> None:
             lines,
             args.name if args.name else os.path.normpath(args.input),
         )
-        text_format.PrintMessage(document, sink, as_utf8=True)
+        textproto.write_document(document, args.output)
 
 
 if __name__ == "__main__":

--- a/src/textproto.py
+++ b/src/textproto.py
@@ -1,0 +1,35 @@
+"""Code for reading and writing scansion text-format protocol buffers."""
+
+
+from google.protobuf import text_format  # type: ignore
+
+import scansion_pb2  # type: ignore
+
+
+# TODO(kbg): Add read and write functions for Verse messages, if needed.
+
+
+def read_document(path: str) -> scansion_pb2.Document:
+    """Reads document message from file.
+
+    Args:
+     path: file path to read from.
+
+    Returns:
+       A parsed document message.
+    """
+    document = scansion_pb2.Document()
+    with open(path, "r") as source:
+        text_format.ParseLines(source, document)
+    return document
+
+
+def write_document(document: scansion_pb2.Document, path: str) -> None:
+    """Writes docuemnt message to file.
+
+    Args:
+      document: the document message to write
+      path: file path to write to.
+    """
+    with open(path, "w") as sink:
+        text_format.PrintMessage(document, sink, as_utf8=True)

--- a/src/validate.py
+++ b/src/validate.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""Validates Document textprotos."""
+
+import argparse
+import logging
+
+import textproto
+
+
+def main(args: argparse.Namespace) -> None:
+    for path in args.textproto:
+        try:
+            document = textproto.read_document(path)
+            logging.info("Successfully validated %s", path)
+            if args.canonicalize:
+                logging.info("Canonicalizing contents of %s", path)
+                textproto.write_document(document, path)
+        except Exception as err:
+            logging.info("Validation of %s failed: %s", path, err)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format="%(levelname)s: %(message)s", level="INFO")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "textproto", nargs="+", help="path for input textproto"
+    )
+    parser.add_argument(
+        "--canonicalize",
+        action="store_true",
+        help="canonicalize input textprotos upon successful parse?",
+    )
+    main(parser.parse_args())


### PR DESCRIPTION
1. a special textproto helper util module `textproto.py` is added.
2. `scan.py` is made to use it and given a light cleanup
3. `validate.py` is added, with the obvious behavior. (note that unlike `scan.py`, it can take multiple input arguments)

Closes #75.