### PR TITLE
Updates CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,15 @@ workflows:
   version: 2
   test:
     jobs:
+      - build-python-3.7
       - build-python-3.8
       - build-python-3.9
-      - test-python-3.8
+      - test-python-3.9
 
 jobs:
-  build-python-3.8: &template
+  build-python-3.7: &template
     docker:
-      - image: python:3.8
+      - image: python:3.7
     steps:
       - checkout
       - run:
@@ -35,6 +36,10 @@ jobs:
           name: Runs black check
           working_directory: ~/project
           command: black --line-length 79 --check --exclude latin_scansion/scansion_pb2.py latin_scansion setup.py tests
+  build-python-3.8:
+    <<: *template
+    docker:
+      - image: python:3.8
   build-python-3.9:
     <<: *template
     docker:
@@ -75,3 +80,10 @@ jobs:
               source ~/.bashrc
               conda activate scansion
               latin_validate --help
+      - run:
+          name: Runs latin_validate on .textprotos
+          working_directory: ~/project
+          command: |
+              source ~/.bashrc
+              conda activate scansion
+              latin_validate data/*/*.textproto

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ workflows:
       - build-python-3.7
       - build-python-3.8
       - build-python-3.9
-      - test-python-3.9
+      - test-python
 
 jobs:
   build-python-3.7: &template
@@ -44,7 +44,7 @@ jobs:
     <<: *template
     docker:
       - image: python:3.9
-  test-python-3.8:
+  test-python:
     docker:
       - image: continuumio/miniconda3
     steps:


### PR DESCRIPTION
1. Runs build test on Python 3.7-3.9 (previously 3.7 was left off)
2. Runs latin_validate over *.textproto.


Closes #95.