### PR TITLE
Reoders variable rule declarations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,10 @@ workflows:
   version: 2
   test:
     jobs:
+      - build-python-3.7
       - build-python-3.8
       - build-python-3.9
-      - test-python-3.8
-
+      - test-python
 jobs:
   build-python-3.8: &template
     docker:
@@ -39,7 +39,7 @@ jobs:
     <<: *template
     docker:
       - image: python:3.9
-  test-python-3.8:
+  test-python:
     docker:
       - image: continuumio/miniconda3
     steps:

--- a/grammars/variable.grm
+++ b/grammars/variable.grm
@@ -11,13 +11,6 @@ h_deletion = Optimize[
     CDRewrite[u.Delete["h"] <10>, "", "", sigma_star, 'ltr', 'opt']
 ];
 
-# A final syllable ending in a vowel, letter m, or diphthong is removed
-# before a word beginning with a vowel (or an h-).
-elision = Optimize[
-    CDRewrite[u.Delete[(i.PHONEMIC_VOWEL | "oj" | "aj" | "aw") " "] <1000>,
-                        "", i.PHONEMIC_VOWEL, sigma_star, 'ltr', 'opt']
-];
-
 # Word-final consonant reattaches to the following word with an initial vowel.
 # TODO: orthographically annotate using "‿".
 resyllabification = Optimize[
@@ -25,6 +18,13 @@ resyllabification = Optimize[
               "", i.CONSONANT " " i.PHONEMIC_VOWEL, sigma_star, 'ltr', 'opt'] @
     CDRewrite[u.Delete[" "] <100>,
               " " i.CONSONANT, i.PHONEMIC_VOWEL, sigma_star]
+];
+
+# A final syllable ending in a vowel, letter m, or diphthong is removed
+# before a word beginning with a vowel (or an h-).
+elision = Optimize[
+    CDRewrite[u.Delete[(i.PHONEMIC_VOWEL | "oj" | "aj" | "aw") " "] <1000>,
+                        "", i.PHONEMIC_VOWEL, sigma_star, 'ltr', 'opt']
 ];
 
 # High vowels may strengthen to their corresponding glides when adjacent to


### PR DESCRIPTION
Variable rules are now declared in the order they apply, and in order of their weight/precedence. This has no effect on the
grammar generated; it is just a cleanup for humans. 